### PR TITLE
fix: replace docker compose restart with down && up -d in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Docker Compose stack for running Paperless-ngx with optional local AI capabiliti
    - In Paperless, go to Profile → API Tokens → Generate
    - Copy the token and add it to `./paperless-ai/.env` and `./paperless-gpt/.env`
    - Update `./paperless-ai/.env` with Paperless username
-   - Restart services: `docker compose restart`
+   - Restart services: `docker compose down && docker compose up -d`
 
 **The AI components are entirely optional** and can be disabled by commenting them out. Paperless works great without AI.
 


### PR DESCRIPTION
`docker compose restart` does not reload env_file variables from docker-compose.yml. 
(Took me 20 Minutes to realise while digging through the docker logs... ;) )

Updated environment variables (e.g. API tokens) remain at their old placeholder values
until the containers are fully recreated with `docker compose down && docker compose up -d`.

Fixes the Quick Start Step 5 which causes silent 401 auth failures in paperless-ai
when users follow the instructions as written.

